### PR TITLE
jugrc creation bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def get_content(filename):
 setuptools.setup(
   include_package_data=True,
   name='sap',
-  version='1.0.4',
+  version='1.0.5',
   description='simple action pipeline python package',
   author='matscorse',
   author_email='matsco@bas.ac.uk',

--- a/src/sap/utils.py
+++ b/src/sap/utils.py
@@ -121,8 +121,10 @@ class build:
         '''
         try:
             #re-write the user's jugrc config file
-            os.system("mkdir -p $HOME/.config")
-            os.system("echo $'[main]\njugdir=recent.%(jugfile)s\nwill_cite=True\n' > $HOME/.config/jugrc")
+            jug_config_dir = os.path.join(os.getenv("HOME"), ".config" )
+            os.makedirs( jug_config_dir, exist_ok = True )
+            with open( os.path.join( jug_config_dir, "jugrc" ), "w" ) as rcfile:
+                rcfile.write( "[main]\njugdir=recent.%(jugfile)s\nwill_cite=True\n" )
             retval = True
         except:
             logger.error("Unable to configure JUG workflow manager")


### PR DESCRIPTION
Bug identified in issue #19 

- Behaviour of automatic jugfile creation not consistent across differen't BASH versions.
- Fix implemented by using Python native file creation instead of platform dependant 'bash' and 'echo'

Reviews from @thomaszwagerman , @bnubald or @davidwilby welcome.